### PR TITLE
fix: Write stdout & stderr to a file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "oclif-typescript"
   ],
   "rules": {
-    "indent": ["error", 2, {"MemberExpression": 1}]
+    "indent": ["error", 2, {"MemberExpression": 1}],
+    "no-console": "off"
   }
 }

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -52,10 +52,10 @@ export default class Launch extends Command {
       avdsToLaunch = await getUserSelectedAVDs(availableAvds)
     }
 
-    avdsToLaunch.forEach(avd => {
-      process.stdout.write(`Launching ${avd}...`)
-      avdManager.launch(avd, createLaunchOptions(flags))
-      process.stdout.write('done.\n')
+    avdsToLaunch.forEach(async avd => {
+      console.log(`Launching ${avd}...`)
+      await avdManager.launch(avd, createLaunchOptions(flags))
+      console.log('done.')
     })
   }
 }


### PR DESCRIPTION
Instead of ignoring stdout or stderr from the emulator, write it to a temporary file. Fixes #21.